### PR TITLE
Add skip-ref and skip-dis cli options

### DIFF
--- a/crates/turbo-metrics-cli/README.md
+++ b/crates/turbo-metrics-cli/README.md
@@ -72,6 +72,16 @@ Options:
 
           [default: 0]
 
+      --skip-ref <SKIP_REF>
+          Index of the first frame to start computing at the reference frame. Additive with `skip`
+
+          [default: 0]
+
+      --skip-dis <SKIP_DIS>
+          Index of the first frame to start computing at the distorted frame. Additive with `skip`
+
+          [default: 0]
+
       --output <OUTPUT>
           Choose the CLI stdout format. Omit the option for the default. Status messages will be printed to stderr in all cases
 

--- a/crates/turbo-metrics-cli/src/main.rs
+++ b/crates/turbo-metrics-cli/src/main.rs
@@ -36,6 +36,12 @@ struct CliArgs {
     /// Index of the first frame to start computing at. Useful for overlaying separate computations with `every`.
     #[arg(long, default_value = "0")]
     skip: u32,
+    /// Index of the first frame to start computing at the reference frame. Additive with `skip`.
+    #[arg(long, default_value = "0")]
+    skip_ref: u32,
+    /// Index of the first frame to start computing at the distorted frame. Additive with `skip`.
+    #[arg(long, default_value = "0")]
+    skip_dis: u32,
 
     /// Choose the CLI stdout format. Omit the option for the default.
     /// Status messages will be printed to stderr in all cases.
@@ -69,6 +75,8 @@ impl CliArgs {
         VideoOptions {
             every: self.every,
             skip: self.skip,
+            skip_ref: self.skip_ref,
+            skip_dis: self.skip_dis,
         }
     }
 
@@ -95,8 +103,8 @@ fn main() -> ExitCode {
         if probe_ref.can_decode() {
             if let Some(probe_dis) = probe_image(&mut in_dis) {
                 if probe_dis.can_decode() {
-                    if args.every != 0 || args.skip != 0 {
-                        eprintln!("WARN: --every and --skip are useless with a pair of images");
+                    if args.every != 0 || args.skip != 0 || args.skip_ref != 0 || args.skip_dis != 0 {
+                        eprintln!("WARN: --every and --skip[_ref/_dist] are useless with a pair of images");
                     }
 
                     init_cuda();

--- a/crates/turbo-metrics/src/lib.rs
+++ b/crates/turbo-metrics/src/lib.rs
@@ -420,8 +420,8 @@ pub fn process_video_pair(
                 //     || decode_count == 1101
                 //     || decode_count == 1151
                 // {
-                //     save_img_f32(&lrgb_ref, &format!("lrgb_ref{}", decode_count), &streams[0])));
-                //     save_img_f32(&lrgb_dis, &format!("lrgb_dis{}", decode_count), &streams[0]);
+                //     save_img_f32(&lrgb_ref, &format!("lrgb_ref{}", decode_count), &streams[0]);
+                //     save_img_f32(&lrgb_dis, &format!("lrgb_dis{}", decode_count), &streams[1]);
                 //     //println!("Saved image!");
                 //     // break 'main;
                 // }
@@ -508,6 +508,7 @@ pub fn process_video_pair(
             }
         }
     }
+    println!();
 
     let duration = start.elapsed();
     let fps = compute_count as u128 * 1000 / duration.as_millis();


### PR DESCRIPTION
Adds two new arguments to the program:

- `--skip-ref <SKIP_REF>`: skips the first `SKIP_REF` frames of the reference video. Defaults to 0.
- `--skip-dis <SKIP_DIS>`: skips the first `SKIP_DIS` frames of the distorted video. Defaults to 0.

These arguments are additive to `--skip`. That is, the program will not perform any computations on the respective input for the amount of frames equal to the **sum of the amounts** specified in `--skip` and `--skip_[ref/dis]`.

These arguments are useful in case one of the inputs is trimmed with respect to the other; e.g., an intro has been cut from the distorted video in addition to being lossily encoded.

This feature could have been achieved more or less similarly by using FFmpeg to trim an input and pipe it to stdout, and reading one of the videos from stdin in turbo-metrics. However, currently there are multiple limitations in turbo-metrics that make this impractical:

- Working with raw video streams is not supported yet, so the input would have to be either imperfectly cut in FFmpeg (potentially losing information due to loss of "reference" frames), or transcoded.
- Only the distorted video can be piped from stdin.
  * This further means that only the distorted video could have been trimmed, and not the reference one.

Also, an in-place-modified counter of how many frames have been decoded by the program so far has been added. Just to give some kind of real-time update information to the user, so that the program does not seem like it's idle.

**Please, review this code before merging.** I am not very familiar with Rust nor the Nvidia Video SDK API, and maybe the developed implementation can be significantly improved.