### PR TITLE
Add frame_count cli option

### DIFF
--- a/crates/turbo-metrics-cli/README.md
+++ b/crates/turbo-metrics-cli/README.md
@@ -82,6 +82,11 @@ Options:
 
           [default: 0]
 
+      --frame-count <FRAME_COUNT>
+          Amount of frames to compute. Useful for computing subsets with `skip`, `skip-ref`, and `skip-dis`
+
+          [default: 0]
+
       --output <OUTPUT>
           Choose the CLI stdout format. Omit the option for the default. Status messages will be printed to stderr in all cases
 

--- a/crates/turbo-metrics-cli/src/main.rs
+++ b/crates/turbo-metrics-cli/src/main.rs
@@ -42,6 +42,9 @@ struct CliArgs {
     /// Index of the first frame to start computing at the distorted frame. Additive with `skip`.
     #[arg(long, default_value = "0")]
     skip_dis: u32,
+    /// Amount of frames to compute. Useful for computing subsets with `skip`, `skip-ref`, and `skip-dis`.
+    #[arg(long, default_value = "0")]
+    frame_count: u32,
 
     /// Choose the CLI stdout format. Omit the option for the default.
     /// Status messages will be printed to stderr in all cases.
@@ -77,6 +80,7 @@ impl CliArgs {
             skip: self.skip,
             skip_ref: self.skip_ref,
             skip_dis: self.skip_dis,
+            frame_count: self.frame_count,
         }
     }
 
@@ -103,8 +107,8 @@ fn main() -> ExitCode {
         if probe_ref.can_decode() {
             if let Some(probe_dis) = probe_image(&mut in_dis) {
                 if probe_dis.can_decode() {
-                    if args.every != 0 || args.skip != 0 || args.skip_ref != 0 || args.skip_dis != 0 {
-                        eprintln!("WARN: --every and --skip[_ref/_dist] are useless with a pair of images");
+                    if args.every != 0 || args.skip != 0 || args.skip_ref != 0 || args.skip_dis != 0  || args.frame_count != 0 {
+                        eprintln!("WARN: --every, --skip[_ref/_dist], and --frame-count are useless with a pair of images");
                     }
 
                     init_cuda();

--- a/crates/turbo-metrics/src/lib.rs
+++ b/crates/turbo-metrics/src/lib.rs
@@ -399,7 +399,7 @@ pub fn process_video_pair(
                     continue;
                 }
 
-                if decode_count - opts.skip >= opts.frame_count {
+                if opts.frame_count > 0 && decode_count - opts.skip >= opts.frame_count {
                     break 'main;
                 }
 

--- a/crates/turbo-metrics/src/lib.rs
+++ b/crates/turbo-metrics/src/lib.rs
@@ -54,6 +54,8 @@ pub struct VideoOptions {
     pub skip_ref: u32,
     /// Index of the first frame to start computing at for the distorted frame.
     pub skip_dis: u32,
+    /// Amount of frames to compute. Useful for computing subsets with `skip`, `skip-ref`, and `skip-dis`.
+    pub frame_count: u32,
 }
 
 #[derive(Debug)]
@@ -396,6 +398,11 @@ pub fn process_video_pair(
                     decode_count += 1;
                     continue;
                 }
+
+                if decode_count - opts.skip >= opts.frame_count {
+                    break 'main;
+                }
+
                 decode_count += 1;
                 print!("\rDecoding frame {}", decode_count);
 


### PR DESCRIPTION
# Subsets and Offsets

Users may not want to compute the metrics for an entire video. Users need to define a subset or range of frames in which the metrics are computed. With the addition of `--skip` and its counterparts (thanks to @0xb01u for PR #6), they can define the start of the range and begin processing in the middle of a video. However, that alone does not allow them to *stop* processing before the end.

This PR adds a new argument to `turbo-metrics-cli`, `--frame-count <FRAME_COUNT>`, which limits the amount of frames to be computed. While `--skip`, `--skip-ref`, and `--skip-dis` limits what is computed from the start of the video, `--frame-count` limits how many frames are decoded and computed *after* the "skips" are applied. By default the value is 0 and the entire video is decoded. This reduces the amount of computation needed for comparing a specific scene or *subset* of a video. Used with `--skip` and `--every`, `--frame-count` provides the final component for optimizing how many frames are processed.

# Examples

A reference video and distorted video contain 100,000 frames and we only need output for the first 10,000 frames. Prior to this PR, you would either decode and compute the entire video or use a transcode containing only those 10,000 frames. If we add `--frame-count 10000` to the command we can avoid an unnecessary transcode and exit the compute loop once the count/limit has been reached.

### Example 1 - First 10,000 Frames

`turbo-metrics reference.mkv distorted.mkv --metrics ssimulacra2 --frame-count 10000`
```
Using device NVIDIA GeForce GTX 1070 with CUDA version 12070
Reference: H.264/AVC   , 1920x1080, CP: BT709, MC: BT709, TC: BT709, CR: Limited
Distorted: H.264/AVC   , 1920x1080, CP: BT709, MC: BT709, TC: BT709, CR: Limited
Initializing SSIMULACRA2
Initialized, now processing ...

Decoding frame 10000
Decoded: 10000, processed: 10000 frame pairs in 3 m 24 s 629 ms (48 fps) (Mpx/s: 101.335)
SSIMULACRA2: Stats {
    min: 47.775732589789676,
    max: 99.99457340297727,
    mean: 82.24837688190661,
    var: 18.02108100702118,
    sample_var: 18.022883295350713,
    stddev: 4.245124380630228,
    sample_stddev: 4.245336652769803,
    p1: 70.49789271620476,
    p5: 73.78791413791893,
    p50: 83.36525844267247,
    p95: 86.49177044763692,
    p99: 94.10156438227006,
}
```

### Example 2 - Every Other of the 2nd 10,000 Frames

`turbo-metrics.exe reference.mkv distorted.mkv --metrics ssimulacra2 --skip 10000 --every 2 --frame-count 10000`
```
Using device NVIDIA GeForce GTX 1070 with CUDA version 12070
Reference: H.264/AVC   , 1920x1080, CP: BT709, MC: BT709, TC: BT709, CR: Limited
Distorted: H.264/AVC   , 1920x1080, CP: BT709, MC: BT709, TC: BT709, CR: Limited
Initializing SSIMULACRA2
Initialized, now processing ...

Decoding frame 19999
Decoded: 20000, processed: 5000 frame pairs in 3 m 17 s 681 ms (25 fps) (Mpx/s: 52.448)
SSIMULACRA2: Stats {
    min: 74.10722962123639,
    max: 87.16398277863098,
    mean: 81.48584366213389,
    var: 5.780282818568969,
    sample_var: 5.781439106390247,
    stddev: 2.404221873822998,
    sample_stddev: 2.4044623320797203,
    p1: 75.88071107616994,
    p5: 77.97321298667629,
    p50: 81.26193848092751,
    p95: 85.49927378232984,
    p99: 85.94609221883401,
}
```

Notice that skipping the first 10,000 frames still requires decoding those first 10,000 frames which incurs a massive penalty that affects the processing time and the FPS value. If possible, it would be far more performant to decode from the first GoP/keyframe that includes the first frame rather than from the very start. FPS can also be made more accurate if we start the processing timer *after* the skipped frames are discarded. These are just some tangential considerations to be made in a separate issue but it was worth bringing up as the processing time appears "wrong."

## Considerations

Rust is quite new to me so I don't know best practices for things like command line argument parsing or how the integrated libraries work. Also, the name `frame-count` may not be the best to convey the usage of the argument and we could use `--frame-limit` or `compute-limit` instead. Naming things appropriately is as difficult as is important sometimes.

Thank you,
\- Boats