### PR TITLE
Fix frame_count cli option logic when using skip

### DIFF
--- a/crates/turbo-metrics-cli/README.md
+++ b/crates/turbo-metrics-cli/README.md
@@ -82,6 +82,11 @@ Options:
 
           [default: 0]
 
+      --frame-count <FRAME_COUNT>
+          Amount of frames to compute. Useful for computing subsets with `skip`, `skip-ref`, and `skip-dis`
+
+          [default: 0]
+
       --output <OUTPUT>
           Choose the CLI stdout format. Omit the option for the default. Status messages will be printed to stderr in all cases
 

--- a/crates/turbo-metrics-cli/src/main.rs
+++ b/crates/turbo-metrics-cli/src/main.rs
@@ -50,7 +50,7 @@ struct CliArgs {
     skip_dis: u32,
     /// Amount of frames to compute. Useful for computing subsets with `skip`, `skip-ref`, and `skip-dis`.
     #[arg(long, default_value = "0")]
-    frame_count: u32,
+    frames: u32,
 
     /// Choose the CLI stdout format. Omit the option for the default.
     /// Status messages will be printed to stderr in all cases.
@@ -86,7 +86,7 @@ impl CliArgs {
             skip: self.skip,
             skip_ref: self.skip_ref,
             skip_dis: self.skip_dis,
-            frame_count: self.frame_count,
+            frames: self.frames,
         }
     }
 

--- a/crates/turbo-metrics-cli/src/main.rs
+++ b/crates/turbo-metrics-cli/src/main.rs
@@ -42,6 +42,9 @@ struct CliArgs {
     /// Index of the first frame to start computing at the distorted frame. Additive with `skip`.
     #[arg(long, default_value = "0")]
     skip_dis: u32,
+    /// Amount of frames to compute. Useful for computing subsets with `skip`, `skip-ref`, and `skip-dis`.
+    #[arg(long, default_value = "0")]
+    frame_count: u32,
 
     /// Choose the CLI stdout format. Omit the option for the default.
     /// Status messages will be printed to stderr in all cases.
@@ -77,6 +80,7 @@ impl CliArgs {
             skip: self.skip,
             skip_ref: self.skip_ref,
             skip_dis: self.skip_dis,
+            frame_count: self.frame_count,
         }
     }
 
@@ -103,8 +107,8 @@ fn main() -> ExitCode {
         if probe_ref.can_decode() {
             if let Some(probe_dis) = probe_image(&mut in_dis) {
                 if probe_dis.can_decode() {
-                    if args.every != 0 || args.skip != 0 || args.skip_ref != 0 || args.skip_dis != 0 {
-                        eprintln!("WARN: --every and --skip[_ref/_dist] are useless with a pair of images");
+                    if args.every != 0 || args.skip != 0 || args.skip_ref != 0 || args.skip_dis != 0  || args.frame_count != 0 {
+                        eprintln!("WARN: --every, --skip[_ref/_dist], and --frame-count are useless with a pair of images");
                     }
 
                     init_cuda();

--- a/crates/turbo-metrics/src/lib.rs
+++ b/crates/turbo-metrics/src/lib.rs
@@ -399,7 +399,7 @@ pub fn process_video_pair(
                     continue;
                 }
 
-                if decode_count - opts.skip >= opts.frame_count {
+                if opts.frame_count > 0 && decode_count - opts.skip >= opts.frame_count {
                     break 'main;
                 }
 

--- a/crates/turbo-metrics/src/lib.rs
+++ b/crates/turbo-metrics/src/lib.rs
@@ -51,7 +51,7 @@ pub struct Options {
     /// Index of the first frame to start computing at for the distorted frame.
     pub skip_dis: u32,
     /// Amount of frames to compute. Useful for computing subsets with `skip`, `skip-ref`, and `skip-dis`.
-    pub frame_count: u32,
+    pub frames: u32,
 }
 
 #[derive(Debug)]
@@ -290,12 +290,13 @@ pub fn compute_metrics(
             decode_count += 1;
             continue;
         }
-
-        if opts.frame_count > 0 && decode_count - opts.skip >= opts.frame_count {
+        
+        decode_count += 1;
+        
+        if opts.frames > 0 && decode_count > opts.frames {
             break;
         }
 
-        decode_count += 1;
         trace!(frame = decode_count, "Computing metrics for frame");
 
         convert_frame_to_linearrgb(

--- a/crates/turbo-metrics/src/lib.rs
+++ b/crates/turbo-metrics/src/lib.rs
@@ -54,6 +54,8 @@ pub struct VideoOptions {
     pub skip_ref: u32,
     /// Index of the first frame to start computing at for the distorted frame.
     pub skip_dis: u32,
+    /// Amount of frames to compute. Useful for computing subsets with `skip`, `skip-ref`, and `skip-dis`.
+    pub frame_count: u32,
 }
 
 #[derive(Debug)]
@@ -396,6 +398,11 @@ pub fn process_video_pair(
                     decode_count += 1;
                     continue;
                 }
+
+                if decode_count - opts.skip >= opts.frame_count {
+                    break 'main;
+                }
+
                 decode_count += 1;
                 print!("\rDecoding frame {}", decode_count);
 


### PR DESCRIPTION
With the recent refactor, the `skip` feature no longer affects the `decode_count` value. This means the decode_count starts at 0 *after* skipping and we no longer need to subtract the `skip` value from the `decode_count` value before checking if the frames quota has been reached. This PR also simplifies the argument by making it shorter as suggested by @Gui-Yom in PR #7. Should there be a naming conflict in the future we can cross that bridge when we get there.

Thank you,
\- Boats