### PR TITLE
Add live per-frame scores in trace output

### DIFF
--- a/crates/turbo-metrics/src/lib.rs
+++ b/crates/turbo-metrics/src/lib.rs
@@ -377,16 +377,21 @@ pub fn compute_metrics(
         streams[0].sync().unwrap();
 
         if let Some(scores_psnr) = &mut scores_psnr {
+            trace!("PSNR {} {}", compute_count, psnr);
             scores_psnr.push(psnr as f64);
         }
         if let Some(scores_ssim) = &mut scores_ssim {
+            trace!("SSIM {} {}", compute_count, ssim);
             scores_ssim.push(ssim as f64);
         }
         if let Some(scores_msssim) = &mut scores_msssim {
+            trace!("MSSSIM {} {}", compute_count, msssim);
             scores_msssim.push(msssim as f64);
         }
         if let Some(scores_ssimu) = &mut scores_ssimu {
-            scores_ssimu.push(ssimu.as_mut().unwrap().get_score());
+            let ssimu = ssimu.as_mut().unwrap().get_score();
+            trace!("SSIMULACRA2 {} {}", compute_count, ssimu);
+            scores_ssimu.push(ssimu);
         }
 
         compute_count += 1;


### PR DESCRIPTION
Prior to the addition of the new output formats, the cli option `frame-score-only` allowed users to get real-time progress on scores as each frame is computed. This was particularly useful for consuming applications to track and cache progress throughout the process. In the case that some failure occurs, those applications could keep the data they already cached and resume in the middle rather than restarting the whole process. This PR returns that functionality via the newly implemented `tracing` crate by logging the name of the metric, the frame computed, and the score - all separated by spaces as a start.

### Output Example

```ps
> $env:RUST_LOG="trace"

> turbo-metrics reference.mkv distorted.mkv --metrics ssimulacra2 --metrics psnr --skip 1 --frames 10 --output json
DEBUG turbo_metrics: Using device NVIDIA GeForce GTX 1070 with CUDA version 12070
TRACE turbo_metrics::input_video: parse SEI (15 bytes)
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse SliceIDR (482 bytes)
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
DEBUG cudarse_video::dec_simple: surfaces=8
TRACE turbo_metrics::input_video: parse SEI (15 bytes)
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse SliceIDR (1163 bytes)
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
DEBUG cudarse_video::dec_simple: surfaces=8
 INFO reference: codec=Mkv/H264/NVDEC width=1920 height=1080 cp=BT709 mc=BT709 tc=BT709 cr=Limited
 INFO distorted: codec=Mkv/H264/NVDEC width=1920 height=1080 cp=BT709 mc=BT709 tc=BT709 cr=Limited
DEBUG turbo_metrics: Initializing PSNR
DEBUG turbo_metrics: Initializing SSIMULACRA2
DEBUG turbo_metrics: Initialized, now processing ...
TRACE turbo_metrics::input_video: parse Slice (72 bytes)
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 0 (482 bytes)
TRACE turbo_metrics::input_video: parse Slice (535 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 1 (72 bytes)
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (534 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 2 (535 bytes)
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (534 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 3 (534 bytes)
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (74 bytes)
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 4 (534 bytes)
TRACE turbo_metrics::input_video: parse Slice (535 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 5 (74 bytes)
TRACE cudarse_video::dec_simple: display 0
TRACE turbo_metrics::input_video: parse Slice (95 bytes)
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 0 (1163 bytes)
TRACE turbo_metrics::input_video: parse Slice (541 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 1 (95 bytes)
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (540 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 2 (541 bytes)
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (534 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 3 (540 bytes)
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (74 bytes)
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 4 (534 bytes)
TRACE turbo_metrics::input_video: parse Slice (535 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 5 (74 bytes)
TRACE cudarse_video::dec_simple: display 0
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (534 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 6 (535 bytes)
TRACE cudarse_video::dec_simple: display 3
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (534 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 6 (535 bytes)
TRACE cudarse_video::dec_simple: display 3
TRACE turbo_metrics: Computing metrics for frame frame=1
TRACE turbo_metrics: PSNR 0 inf
TRACE turbo_metrics: SSIMULACRA2 0 99.99457340297727
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (534 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 7 (534 bytes)
TRACE cudarse_video::dec_simple: display 2
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (534 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 7 (534 bytes)
TRACE cudarse_video::dec_simple: display 2
TRACE turbo_metrics: Computing metrics for frame frame=2
TRACE turbo_metrics: PSNR 1 inf
TRACE turbo_metrics: SSIMULACRA2 1 99.99457340297727
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (11854 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 0 (534 bytes)
TRACE cudarse_video::dec_simple: display 4
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (17472 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 0 (534 bytes)
TRACE cudarse_video::dec_simple: display 4
TRACE turbo_metrics: Computing metrics for frame frame=3
TRACE turbo_metrics: PSNR 2 inf
TRACE turbo_metrics: SSIMULACRA2 2 99.99457340297727
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (535 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 3 (11854 bytes)
TRACE cudarse_video::dec_simple: display 1
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (535 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 3 (17472 bytes)
TRACE cudarse_video::dec_simple: display 1
TRACE turbo_metrics: Computing metrics for frame frame=4
TRACE turbo_metrics: PSNR 3 inf
TRACE turbo_metrics: SSIMULACRA2 3 99.99457340297727
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (534 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 4 (535 bytes)
TRACE cudarse_video::dec_simple: display 7
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (534 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 4 (535 bytes)
TRACE cudarse_video::dec_simple: display 7
TRACE turbo_metrics: Computing metrics for frame frame=5
TRACE turbo_metrics: PSNR 4 inf
TRACE turbo_metrics: SSIMULACRA2 4 99.99457340297727
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (9880 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 2 (534 bytes)
TRACE cudarse_video::dec_simple: display 6
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (12734 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 2 (534 bytes)
TRACE cudarse_video::dec_simple: display 6
TRACE turbo_metrics: Computing metrics for frame frame=6
TRACE turbo_metrics: PSNR 5 inf
TRACE turbo_metrics: SSIMULACRA2 5 99.99457340297727
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (20577 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 1 (9880 bytes)
TRACE cudarse_video::dec_simple: display 0
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (22455 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 1 (12734 bytes)
TRACE cudarse_video::dec_simple: display 0
TRACE turbo_metrics: Computing metrics for frame frame=7
TRACE turbo_metrics: PSNR 6 inf
TRACE turbo_metrics: SSIMULACRA2 6 99.99457340297727
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (13559 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 7 (20577 bytes)
TRACE cudarse_video::dec_simple: display 5
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (12532 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 7 (22455 bytes)
TRACE cudarse_video::dec_simple: display 5
TRACE turbo_metrics: Computing metrics for frame frame=8
TRACE turbo_metrics: PSNR 7 inf
TRACE turbo_metrics: SSIMULACRA2 7 99.99457340297727
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (10268 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 0 (13559 bytes)
TRACE cudarse_video::dec_simple: display 2
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (7234 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 0 (12532 bytes)
TRACE cudarse_video::dec_simple: display 2
TRACE turbo_metrics: Computing metrics for frame frame=9
TRACE turbo_metrics: PSNR 8 inf
TRACE turbo_metrics: SSIMULACRA2 8 99.99457340297727
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (11100 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 6 (10268 bytes)
TRACE cudarse_video::dec_simple: display 4
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (6826 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 6 (7234 bytes)
TRACE cudarse_video::dec_simple: display 4
TRACE turbo_metrics: Computing metrics for frame frame=10
TRACE turbo_metrics: PSNR 9 inf
TRACE turbo_metrics: SSIMULACRA2 9 99.99457340297727
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (24542 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 5 (11100 bytes)
TRACE cudarse_video::dec_simple: display 1
TRACE turbo_metrics::input_video: parse SEI (12 bytes)
TRACE turbo_metrics::input_video: parse Slice (24977 bytes)
TRACE cudarse_video::dec_simple: SEI 1 (64 bytes)
TRACE cudarse_video::dec_simple: decode 5 (6826 bytes)
TRACE cudarse_video::dec_simple: display 1
 INFO turbo_metrics: Decoded: 11, processed: 10 frame pairs in 268 ms (37 fps) (Mpx/s: 77.373)
{
  "frame_count": 10,
  "psnr": {
    "scores": [
      null,
      null,
      null,
      null,
      null,
      null,
      null,
      null,
      null,
      null
    ],
    "stats": {
      "min": null,
      "max": null,
      "mean": null,
      "var": null,
      "sample_var": null,
      "stddev": null,
      "sample_stddev": null,
      "p1": null,
      "p5": null,
      "p50": null,
      "p95": null,
      "p99": null
    }
  },
  "ssimulacra2": {
    "scores": [
      99.99457340297727,
      99.99457340297727,
      99.99457340297727,
      99.99457340297727,
      99.99457340297727,
      99.99457340297727,
      99.99457340297727,
      99.99457340297727,
      99.99457340297727,
      99.99457340297727
    ],
    "stats": {
      "min": 99.99457340297727,
      "max": 99.99457340297727,
      "mean": 99.99457340297727,
      "var": 0.0,
      "sample_var": 0.0,
      "stddev": 0.0,
      "sample_stddev": 0.0,
      "p1": 99.99457340297727,
      "p5": 99.99457340297727,
      "p50": 99.99457340297727,
      "p95": 99.99457340297727,
      "p99": 99.99457340297727
    }
  }
}
```

The `compute_count` is 0-indexed and if desired, we can change the output so that it starts at 1 instead.

Thank you,
\- Boats